### PR TITLE
topic/snapshot test for snapshot indexer

### DIFF
--- a/chainsight-cdk-macros/Cargo.toml
+++ b/chainsight-cdk-macros/Cargo.toml
@@ -30,6 +30,7 @@ quote = "1.0.27"
 
 [dev-dependencies]
 insta = { version = "1.34.0", features = ["yaml"] }
+regex = "1.8.4"
 rust-format = "0.3.4"
 tokio = { version = "1.33.0", features = ["full"] }
 

--- a/chainsight-cdk-macros/src/canisters/event_indexer.rs
+++ b/chainsight-cdk-macros/src/canisters/event_indexer.rs
@@ -9,6 +9,8 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse_macro_input;
 
+use crate::canisters::utils::camel_to_snake;
+
 use super::utils::extract_contract_name_from_path;
 
 pub fn def_event_indexer_canister(input: TokenStream) -> TokenStream {
@@ -130,13 +132,6 @@ fn custom_code(config: EventIndexerConfig) -> proc_macro2::TokenStream {
             }.boxed()
         }
     }
-}
-
-/// Convert camelCase String to snake_case
-pub fn camel_to_snake(val: &str) -> String {
-    // NOTE: use Inflator in ic-solidity-bindgen
-    // https://github.com/horizonx-tech/ic-solidity-bindgen/blob/0972bede5957927bcb8f675decd93878b849dc76/ic-solidity-bindgen-macros/src/abi_gen.rs#L192
-    inflector::cases::snakecase::to_snake_case(val)
 }
 
 #[cfg(test)]

--- a/chainsight-cdk-macros/src/canisters/mod.rs
+++ b/chainsight-cdk-macros/src/canisters/mod.rs
@@ -6,3 +6,6 @@ pub mod snapshot_indexer_evm;
 pub mod snapshot_indexer_https;
 pub mod snapshot_indexer_icp;
 pub mod utils;
+
+#[cfg(test)]
+pub mod test_utils;

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_evm.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_evm.rs
@@ -7,9 +7,8 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse_macro_input;
 
-use crate::canisters::{
-    event_indexer::camel_to_snake,
-    utils::{extract_contract_name_from_path, generate_queries_without_timestamp},
+use crate::canisters::utils::{
+    camel_to_snake, extract_contract_name_from_path, generate_queries_without_timestamp,
 };
 
 pub fn def_snapshot_indexer_evm(input: TokenStream) -> TokenStream {

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_evm.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_evm.rs
@@ -8,8 +8,8 @@ use quote::{format_ident, quote};
 use syn::parse_macro_input;
 
 use crate::canisters::{
-    event_indexer::camel_to_snake, snapshot_indexer_https::generate_queries_without_timestamp,
-    utils::extract_contract_name_from_path,
+    event_indexer::camel_to_snake,
+    utils::{extract_contract_name_from_path, generate_queries_without_timestamp},
 };
 
 pub fn def_snapshot_indexer_evm(input: TokenStream) -> TokenStream {

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_evm.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_evm.rs
@@ -254,3 +254,30 @@ pub fn generate_request_arg_idents(
     }
     (value_idents, type_idents)
 }
+
+#[cfg(test)]
+mod test {
+    use chainsight_cdk::config::components::CommonConfig;
+    use insta::assert_display_snapshot;
+
+    use crate::canisters::test_utils::SrcString;
+
+    use super::*;
+
+    #[test]
+    fn test_snapshot() {
+        let config = SnapshotIndexerEVMConfig {
+            common: CommonConfig {
+                monitor_duration: 1000,
+                canister_name: "sample_snapshot_indexer_evm".to_string(),
+            },
+            method_identifier: "totalSupply():(uint256)".to_string(),
+            method_args: vec![],
+            abi_file_path: "examples/minimum_indexers/src/snapshot_indexer_evm/abi/ERC20.json"
+                .to_string(),
+        };
+        let generated = snapshot_indexer_evm(config);
+        let formatted = SrcString::from(&generated);
+        assert_display_snapshot!("snapshot__snapshot_indexer_evm", formatted);
+    }
+}

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_https.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_https.rs
@@ -46,6 +46,7 @@ fn custom_code(config: SnapshotIndexerHTTPSConfig) -> proc_macro2::TokenStream {
     } = config;
 
     let id = &common.canister_name;
+    let duration = &common.monitor_duration;
     let header_keys: Vec<String> = headers.keys().cloned().collect();
     let header_values: Vec<String> = headers.values().cloned().collect();
     let query_keys: Vec<String> = queries.keys().cloned().collect();
@@ -54,7 +55,7 @@ fn custom_code(config: SnapshotIndexerHTTPSConfig) -> proc_macro2::TokenStream {
 
     quote! {
         init_in!();
-        chainsight_common!(60); // TODO: use common.monitor_duration
+        chainsight_common!(#duration);
         snapshot_https_source!();
 
         #[derive(Debug, Clone, candid::CandidType, candid::Deserialize, serde::Serialize, StableMemoryStorable)]
@@ -121,7 +122,7 @@ mod test {
     fn test_snapshot() {
         let config = SnapshotIndexerHTTPSConfig {
             common: CommonConfig {
-                monitor_duration: 1000,
+                monitor_duration: 60,
                 canister_name: "sample_snapshot_indexer_https".to_string(),
             },
             url: "https://api.coingecko.com/api/v3/simple/price".to_string(),

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_https.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_https.rs
@@ -178,3 +178,34 @@ pub fn generate_queries_without_timestamp(
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use chainsight_cdk::config::components::CommonConfig;
+    use insta::assert_display_snapshot;
+
+    use crate::canisters::test_utils::SrcString;
+
+    use super::*;
+
+    #[test]
+    fn test_snapshot() {
+        let config = SnapshotIndexerHTTPSConfig {
+            common: CommonConfig {
+                monitor_duration: 1000,
+                canister_name: "sample_snapshot_indexer_https".to_string(),
+            },
+            url: "https://api.coingecko.com/api/v3/simple/price".to_string(),
+            headers: BTreeMap::from([("content-type".to_string(), "application/json".to_string())]),
+            queries: BTreeMap::from([
+                ("ids".to_string(), "dai".to_string()),
+                ("vs_currencies".to_string(), "usd".to_string()),
+            ]),
+        };
+        let generated = snapshot_indexer_https(config);
+        let formatted = SrcString::from(&generated);
+        assert_display_snapshot!("snapshot__snapshot_indexer_https", formatted);
+    }
+}

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_icp.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_icp.rs
@@ -162,3 +162,29 @@ fn custom_code(config: SnapshotIndexerICPConfig) -> proc_macro2::TokenStream {
         did_export!(#id);
     }
 }
+
+#[cfg(test)]
+mod test {
+    use chainsight_cdk::config::components::CommonConfig;
+    use insta::assert_display_snapshot;
+
+    use crate::canisters::test_utils::SrcString;
+
+    use super::*;
+
+    #[test]
+    fn test_snapshot() {
+        let config = SnapshotIndexerICPConfig {
+            common: CommonConfig {
+                monitor_duration: 1000,
+                canister_name: "sample_snapshot_indexer_icp".to_string(),
+            },
+            method_identifier:
+                "get_last_snapshot : () -> (record { value : text; timestamp : nat64 })".to_string(),
+            lens_targets: None,
+        };
+        let generated = snapshot_indexer_icp(config);
+        let formatted = SrcString::from(&generated);
+        assert_display_snapshot!("snapshot__snapshot_indexer_icp", formatted);
+    }
+}

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_icp.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_icp.rs
@@ -6,7 +6,7 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse_macro_input;
 
-use super::snapshot_indexer_https::generate_queries_without_timestamp;
+use crate::canisters::utils::generate_queries_without_timestamp;
 
 pub fn def_snapshot_indexer_icp(input: TokenStream) -> TokenStream {
     let input_json_string: String = parse_macro_input!(input as syn::LitStr).value();

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_evm__test__snapshot__snapshot_indexer_evm.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_evm__test__snapshot__snapshot_indexer_evm.snap
@@ -1,0 +1,97 @@
+---
+source: chainsight-cdk-macros/src/canisters/snapshot_indexer_evm.rs
+expression: formatted
+---
+use std::str::FromStr;
+use candid::{
+Decode, Encode };
+use chainsight_cdk_macros::{
+init_in, manage_single_state, setup_func, prepare_stable_structure, stable_memory_for_vec, StableMemoryStorable, timer_task_func, define_transform_for_web3, define_web3_ctx, chainsight_common, did_export, snapshot_web3_source };
+use ic_web3_rs::types::Address;
+init_in!();
+chainsight_common!(3600);
+define_web3_ctx!();
+define_transform_for_web3!();
+manage_single_state!("target_addr", String, false);
+setup_func!({
+target_addr:String, web3_ctx_param:chainsight_cdk::web3::Web3CtxParam
+});
+prepare_stable_structure!();
+stable_memory_for_vec!("snapshot", Snapshot, 0, true);
+timer_task_func!("set_task", "execute_task", true);
+#[derive(Debug, Clone, candid::CandidType, candid::Deserialize, serde::Serialize, StableMemoryStorable)]
+#[stable_mem_storable_opts(max_size = 10000, is_fixed_size = false)]
+pub struct Snapshot {
+pub value:SnapshotValue, pub timestamp:u64,
+}
+
+type SnapshotValue =(String);
+fn _get_last_snapshot_value() -> SnapshotValue {
+get_last_snapshot().value
+}
+
+fn _get_top_snapshot_values(n:u64) -> Vec<SnapshotValue>{
+get_top_snapshots(n).iter().map(| s | s.value.clone()).collect()
+}
+
+fn _get_snapshot_value(idx:u64) -> SnapshotValue {
+get_snapshot(idx).value
+}
+
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+pub fn get_last_snapshot_value() -> SnapshotValue {
+_get_last_snapshot_value()
+}
+
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+pub fn get_top_snapshot_values(n:u64) -> Vec<SnapshotValue>{
+_get_top_snapshot_values(n)
+}
+
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+pub fn get_snapshot_value(idx:u64) -> SnapshotValue {
+_get_snapshot_value(idx)
+}
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+pub async fn proxy_get_last_snapshot_value(input:std::vec::Vec<u8>) -> std::vec::Vec<u8>{
+use chainsight_cdk::rpc::Receiver;
+chainsight_cdk::rpc::ReceiverProviderWithoutArgs::< SnapshotValue>:: new(proxy(), _get_last_snapshot_value, ).reply(input).await
+}
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+pub async fn proxy_get_top_snapshot_values(input:std::vec::Vec<u8>) -> std::vec::Vec<u8>{
+use chainsight_cdk::rpc::Receiver;
+chainsight_cdk::rpc::ReceiverProvider::< u64, Vec<SnapshotValue>>::new(proxy(), _get_top_snapshot_values, ).reply(input).await
+}
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+pub async fn proxy_get_snapshot_value(input:std::vec::Vec<u8>) -> std::vec::Vec<u8>{
+use chainsight_cdk::rpc::Receiver;
+chainsight_cdk::rpc::ReceiverProvider::< u64, SnapshotValue>:: new(proxy(), _get_snapshot_value, ).reply(input).await
+}
+
+ic_solidity_bindgen::contract_abi!("examples/minimum_indexers/src/snapshot_indexer_evm/abi/ERC20.json");
+snapshot_web3_source!("total_supply");
+async fn execute_task() {
+let current_ts_sec = ic_cdk::api::time() / 1000000;
+let res = ERC20::new(Address::from_str(& get_target_addr()).unwrap(), & web3_ctx().unwrap()).total_supply(None).await.unwrap();
+let datum = Snapshot {
+value:(res.to_string()), timestamp:current_ts_sec, };
+let _ = add_snapshot(datum.clone());
+ic_cdk::println!("ts={
+
+},  snapshot={
+:?
+}", datum.timestamp, datum.value);
+
+}
+
+did_export!("sample_snapshot_indexer_evm");
+

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_evm__test__snapshot__snapshot_indexer_evm.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_evm__test__snapshot__snapshot_indexer_evm.snap
@@ -9,7 +9,7 @@ use chainsight_cdk_macros::{
 init_in, manage_single_state, setup_func, prepare_stable_structure, stable_memory_for_vec, StableMemoryStorable, timer_task_func, define_transform_for_web3, define_web3_ctx, chainsight_common, did_export, snapshot_web3_source };
 use ic_web3_rs::types::Address;
 init_in!();
-chainsight_common!(3600);
+chainsight_common!(60u32);
 define_web3_ctx!();
 define_transform_for_web3!();
 manage_single_state!("target_addr", String, false);

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_https__test__snapshot__snapshot_indexer_https.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_https__test__snapshot__snapshot_indexer_https.snap
@@ -12,7 +12,7 @@ use candid::{
 Decode, Encode };
 use sample_snapshot_indexer_https::*;
 init_in!();
-chainsight_common!(60);
+chainsight_common!(60u32);
 snapshot_https_source!();
 #[derive(Debug, Clone, candid::CandidType, candid::Deserialize, serde::Serialize, StableMemoryStorable)]
 #[stable_mem_storable_opts(max_size = 10000, is_fixed_size = false)]

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_https__test__snapshot__snapshot_indexer_https.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_https__test__snapshot__snapshot_indexer_https.snap
@@ -1,0 +1,101 @@
+---
+source: chainsight-cdk-macros/src/canisters/snapshot_indexer_https.rs
+expression: formatted
+---
+use std::collections::HashMap;
+use chainsight_cdk::core::HttpsSnapshotIndexerSourceAttrs;
+use chainsight_cdk::web2::{
+HttpsSnapshotParam, Web2HttpsSnapshotIndexer };
+use chainsight_cdk_macros::{
+chainsight_common, did_export, init_in, prepare_stable_structure, stable_memory_for_vec, timer_task_func, snapshot_https_source, StableMemoryStorable, };
+use candid::{
+Decode, Encode };
+use sample_snapshot_indexer_https::*;
+init_in!();
+chainsight_common!(60);
+snapshot_https_source!();
+#[derive(Debug, Clone, candid::CandidType, candid::Deserialize, serde::Serialize, StableMemoryStorable)]
+#[stable_mem_storable_opts(max_size = 10000, is_fixed_size = false)]
+pub struct Snapshot {
+pub value:SnapshotValue, pub timestamp:u64,
+}
+
+prepare_stable_structure!();
+stable_memory_for_vec!("snapshot", Snapshot, 0, true);
+timer_task_func!("set_task", "index", true);
+const URL:& str = "https://api.coingecko.com/api/v3/simple/price";
+fn get_attrs() -> HttpsSnapshotIndexerSourceAttrs {
+HttpsSnapshotIndexerSourceAttrs {
+queries:HashMap::from([("ids".to_string(), "dai".to_string()), ("vs_currencies".to_string(), "usd".to_string()), ]
+),
+}
+
+
+}
+
+async fn index() {
+let indexer = Web2HttpsSnapshotIndexer::new(URL.to_string(), );
+let res = indexer.get::< String, SnapshotValue>(HttpsSnapshotParam {
+headers:vec![("content-type".to_string(), "application/json".to_string()), ]
+.into_iter().collect(), queries:vec![("ids".to_string(), "dai".to_string()), ("vs_currencies".to_string(), "usd".to_string()), ]
+.into_iter().collect(),
+}).await.unwrap();
+let snapshot = Snapshot {
+value:res, timestamp:ic_cdk::api::time() / 1000000, };
+let _ = add_snapshot(snapshot.clone());
+
+}
+
+fn _get_last_snapshot_value() -> SnapshotValue {
+get_last_snapshot().value
+}
+
+fn _get_top_snapshot_values(n:u64) -> Vec<SnapshotValue>{
+get_top_snapshots(n).iter().map(| s | s.value.clone()).collect()
+}
+
+fn _get_snapshot_value(idx:u64) -> SnapshotValue {
+get_snapshot(idx).value
+}
+
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+pub fn get_last_snapshot_value() -> SnapshotValue {
+_get_last_snapshot_value()
+}
+
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+pub fn get_top_snapshot_values(n:u64) -> Vec<SnapshotValue>{
+_get_top_snapshot_values(n)
+}
+
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+pub fn get_snapshot_value(idx:u64) -> SnapshotValue {
+_get_snapshot_value(idx)
+}
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+pub async fn proxy_get_last_snapshot_value(input:std::vec::Vec<u8>) -> std::vec::Vec<u8>{
+use chainsight_cdk::rpc::Receiver;
+chainsight_cdk::rpc::ReceiverProviderWithoutArgs::< SnapshotValue>:: new(proxy(), _get_last_snapshot_value, ).reply(input).await
+}
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+pub async fn proxy_get_top_snapshot_values(input:std::vec::Vec<u8>) -> std::vec::Vec<u8>{
+use chainsight_cdk::rpc::Receiver;
+chainsight_cdk::rpc::ReceiverProvider::< u64, Vec<SnapshotValue>>::new(proxy(), _get_top_snapshot_values, ).reply(input).await
+}
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+pub async fn proxy_get_snapshot_value(input:std::vec::Vec<u8>) -> std::vec::Vec<u8>{
+use chainsight_cdk::rpc::Receiver;
+chainsight_cdk::rpc::ReceiverProvider::< u64, SnapshotValue>:: new(proxy(), _get_snapshot_value, ).reply(input).await
+}
+
+did_export!("sample_snapshot_indexer_https");
+

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp.snap
@@ -10,7 +10,7 @@ use chainsight_cdk::rpc::{
 CallProvider, Caller, Message };
 mod types;
 init_in!();
-chainsight_common!(3600);
+chainsight_common!(60u32);
 manage_single_state!("target_canister", String, false);
 setup_func!({
 target_canister:String

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp.snap
@@ -1,0 +1,120 @@
+---
+source: chainsight-cdk-macros/src/canisters/snapshot_indexer_icp.rs
+expression: formatted
+---
+use candid::{
+Decode, Encode };
+use chainsight_cdk_macros::{
+init_in, manage_single_state, setup_func, prepare_stable_structure, stable_memory_for_vec, StableMemoryStorable, timer_task_func, chainsight_common, did_export, snapshot_icp_source };
+use chainsight_cdk::rpc::{
+CallProvider, Caller, Message };
+mod types;
+init_in!();
+chainsight_common!(3600);
+manage_single_state!("target_canister", String, false);
+setup_func!({
+target_canister:String
+});
+prepare_stable_structure!();
+stable_memory_for_vec!("snapshot", Snapshot, 0, true);
+timer_task_func!("set_task", "execute_task", true);
+#[derive(Clone, Debug, candid::CandidType, candid::Deserialize, serde::Serialize, StableMemoryStorable)]
+#[stable_mem_storable_opts(max_size = 10000, is_fixed_size = false)]
+pub struct Snapshot {
+pub value:SnapshotValue, pub timestamp:u64,
+}
+
+pub type SnapshotValue = types::ResponseType;
+fn _get_last_snapshot_value() -> SnapshotValue {
+get_last_snapshot().value
+}
+
+fn _get_top_snapshot_values(n:u64) -> Vec<SnapshotValue>{
+get_top_snapshots(n).iter().map(| s | s.value.clone()).collect()
+}
+
+fn _get_snapshot_value(idx:u64) -> SnapshotValue {
+get_snapshot(idx).value
+}
+
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+pub fn get_last_snapshot_value() -> SnapshotValue {
+_get_last_snapshot_value()
+}
+
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+pub fn get_top_snapshot_values(n:u64) -> Vec<SnapshotValue>{
+_get_top_snapshot_values(n)
+}
+
+#[ic_cdk::query]
+#[candid::candid_method(query)]
+pub fn get_snapshot_value(idx:u64) -> SnapshotValue {
+_get_snapshot_value(idx)
+}
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+pub async fn proxy_get_last_snapshot_value(input:std::vec::Vec<u8>) -> std::vec::Vec<u8>{
+use chainsight_cdk::rpc::Receiver;
+chainsight_cdk::rpc::ReceiverProviderWithoutArgs::< SnapshotValue>:: new(proxy(), _get_last_snapshot_value, ).reply(input).await
+}
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+pub async fn proxy_get_top_snapshot_values(input:std::vec::Vec<u8>) -> std::vec::Vec<u8>{
+use chainsight_cdk::rpc::Receiver;
+chainsight_cdk::rpc::ReceiverProvider::< u64, Vec<SnapshotValue>>::new(proxy(), _get_top_snapshot_values, ).reply(input).await
+}
+
+#[ic_cdk::update]
+#[candid::candid_method(update)]
+pub async fn proxy_get_snapshot_value(input:std::vec::Vec<u8>) -> std::vec::Vec<u8>{
+use chainsight_cdk::rpc::Receiver;
+chainsight_cdk::rpc::ReceiverProvider::< u64, SnapshotValue>:: new(proxy(), _get_snapshot_value, ).reply(input).await
+}
+
+snapshot_icp_source!("proxy_get_last_snapshot");
+type CallCanisterArgs = sample_snapshot_indexer_icp::CallCanisterArgs;
+pub fn call_args() -> CallCanisterArgs {
+sample_snapshot_indexer_icp::call_args()
+}
+
+type CallCanisterResponse = SnapshotValue;
+async fn execute_task() {
+let current_ts_sec = ic_cdk::api::time() / 1000000;
+let target_canister = candid::Principal::from_text(get_target_canister()).unwrap();
+let px = _get_target_proxy(target_canister).await;
+let call_result = CallProvider::new().call(Message::new::< CallCanisterArgs>(call_args(), px.clone(), "proxy_get_last_snapshot").unwrap()).await;
+if let Err(err) = call_result {
+ic_cdk::println!("error: {
+:?
+}", err);
+return;
+
+}
+
+let res = call_result.unwrap().reply::< CallCanisterResponse>();
+if let Err(err) = res {
+ic_cdk::println!("error: {
+:?
+}", err);
+return;
+
+}
+
+let datum = Snapshot {
+value:res.unwrap().clone(), timestamp:current_ts_sec, };
+let _ = add_snapshot(datum.clone());
+ic_cdk::println!("ts={
+
+},  value={
+:?
+}", datum.timestamp, datum.value);
+
+}
+
+did_export!("sample_snapshot_indexer_icp");
+

--- a/chainsight-cdk-macros/src/canisters/test_utils/mod.rs
+++ b/chainsight-cdk-macros/src/canisters/test_utils/mod.rs
@@ -1,0 +1,40 @@
+use std::fmt;
+
+use proc_macro2::TokenStream;
+
+pub struct SrcString {
+    value: String,
+}
+
+impl From<&TokenStream> for SrcString {
+    fn from(value: &TokenStream) -> Self {
+        Self {
+            value: value.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for SrcString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", simple_src_format(&self.value))
+    }
+}
+
+pub fn simple_src_format(src: &str) -> String {
+    let regex = regex::Regex::new(r" (?:(::|[,.!<>:;(\[])) ?").unwrap();
+    let res = regex.replace_all(src, "$1");
+
+    let regex = regex::Regex::new(r"(,)").unwrap();
+    let res = regex.replace_all(&res, "$1 ");
+
+    let regex = regex::Regex::new(r" ?(\}[^;])").unwrap();
+    let res = regex.replace_all(&res, "\n$1");
+
+    let regex = regex::Regex::new(r"(}) ").unwrap();
+    let res = regex.replace_all(&res, "$1\n\n");
+
+    let regex = regex::Regex::new(r"([;\]]|\{) ?").unwrap();
+    let res = regex.replace_all(&res, "$1\n");
+
+    res.to_string()
+}

--- a/chainsight-cdk-macros/src/canisters/utils.rs
+++ b/chainsight-cdk-macros/src/canisters/utils.rs
@@ -1,9 +1,85 @@
+use quote::quote;
 use std::path::PathBuf;
 
 pub fn extract_contract_name_from_path(s: &str) -> String {
     let path = PathBuf::from(s);
     let name = path.file_stem().expect("file_stem failed");
     name.to_str().expect("to_str failed").to_string()
+}
+
+pub fn generate_queries_without_timestamp(
+    return_type: proc_macro2::Ident,
+) -> proc_macro2::TokenStream {
+    let query_derives = quote! {
+        #[ic_cdk::query]
+        #[candid::candid_method(query)]
+    };
+    let update_derives = quote! {
+        #[ic_cdk::update]
+        #[candid::candid_method(update)]
+    };
+
+    quote! {
+        fn _get_last_snapshot_value() -> #return_type {
+            get_last_snapshot().value
+        }
+
+        fn _get_top_snapshot_values(n: u64) -> Vec<#return_type> {
+            get_top_snapshots(n).iter().map(|s| s.value.clone()).collect()
+        }
+
+        fn _get_snapshot_value(idx: u64) -> #return_type {
+            get_snapshot(idx).value
+        }
+
+        #query_derives
+        pub fn get_last_snapshot_value() -> #return_type {
+            _get_last_snapshot_value()
+        }
+
+        #query_derives
+        pub fn get_top_snapshot_values(n: u64) -> Vec<#return_type> {
+            _get_top_snapshot_values(n)
+        }
+
+        #query_derives
+        pub fn get_snapshot_value(idx: u64) -> #return_type {
+            _get_snapshot_value(idx)
+        }
+
+        #update_derives
+        pub async fn proxy_get_last_snapshot_value(input: std::vec::Vec<u8>) -> std::vec::Vec<u8> {
+            use chainsight_cdk::rpc::Receiver;
+            chainsight_cdk::rpc::ReceiverProviderWithoutArgs::<#return_type>::new(
+                proxy(),
+                _get_last_snapshot_value,
+            )
+            .reply(input)
+            .await
+        }
+
+        #update_derives
+        pub async fn proxy_get_top_snapshot_values(input: std::vec::Vec<u8>) -> std::vec::Vec<u8> {
+            use chainsight_cdk::rpc::Receiver;
+            chainsight_cdk::rpc::ReceiverProvider::<u64, Vec<#return_type>>::new(
+                proxy(),
+                _get_top_snapshot_values,
+            )
+            .reply(input)
+            .await
+        }
+
+        #update_derives
+        pub async fn proxy_get_snapshot_value(input: std::vec::Vec<u8>) -> std::vec::Vec<u8> {
+            use chainsight_cdk::rpc::Receiver;
+            chainsight_cdk::rpc::ReceiverProvider::<u64, #return_type>::new(
+                proxy(),
+                _get_snapshot_value,
+            )
+            .reply(input)
+            .await
+        }
+    }
 }
 
 #[cfg(test)]

--- a/chainsight-cdk-macros/src/canisters/utils.rs
+++ b/chainsight-cdk-macros/src/canisters/utils.rs
@@ -1,6 +1,13 @@
 use quote::quote;
 use std::path::PathBuf;
 
+/// Convert camelCase String to snake_case
+pub fn camel_to_snake(val: &str) -> String {
+    // NOTE: use Inflator in ic-solidity-bindgen
+    // https://github.com/horizonx-tech/ic-solidity-bindgen/blob/0972bede5957927bcb8f675decd93878b849dc76/ic-solidity-bindgen-macros/src/abi_gen.rs#L192
+    inflector::cases::snakecase::to_snake_case(val)
+}
+
 pub fn extract_contract_name_from_path(s: &str) -> String {
     let path = PathBuf::from(s);
     let name = path.file_stem().expect("file_stem failed");


### PR DESCRIPTION
snapshot_indexer_https
```bash
% diff \
chainsight-cli-2/src/lib/codegen/components/snapshots/csx__lib__codegen__components__snapshot_indexer_https__tests__snapshot_outputs.snap \
chainsight-sdk/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_https__test__snapshot__snapshot_indexer_https.snap
2,3c2,3
< source: src/lib/codegen/components/snapshot_indexer_https.rs
< expression: "SrcString::from(&manifest.generate_codes(Option::None).unwrap())"
---
> source: chainsight-cdk-macros/src/canisters/snapshot_indexer_https.rs
> expression: formatted
13,14d12
< init_in!();
< chainsight_common!(60);
15a14,16
> init_in!();
> chainsight_common!(60u32);
> snapshot_https_source!();
48d48
< snapshot_https_source!();
```

snapshot_indexer_icp.rs
```bash
% diff \
chainsight-cli-2/src/lib/codegen/components/snapshots/csx__lib__codegen__components__snapshot_indexer_icp__tests__snapshot_outputs.snap \
chainsight-sdk/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp.snap
2,3c2,3
< source: src/lib/codegen/components/snapshot_indexer_icp.rs
< expression: "SrcString::from(&manifest.generate_codes(Option::None).unwrap().lib)"
---
> source: chainsight-cdk-macros/src/canisters/snapshot_indexer_icp.rs
> expression: formatted
13c13
< chainsight_common!(3600);
---
> chainsight_common!(60u32);
110c110
< add_snapshot(datum.clone());
---
> let _ = add_snapshot(datum.clone());
```

snapshot_indexer_evm

```bash
diff \
chainsight-cli-2/src/lib/codegen/components/snapshots/csx__lib__codegen__components__snapshot_indexer_evm__tests__snapshot_outputs.snap \
chainsight-sdk/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_evm__test__snapshot__snapshot_indexer_evm.snap
2,3c2,3
< source: src/lib/codegen/components/snapshot_indexer_evm.rs
< expression: "SrcString::from(&manifest.generate_codes(Option::Some(ethabi::Contract::load(abi).unwrap())).unwrap())"
---
> source: chainsight-cdk-macros/src/canisters/snapshot_indexer_evm.rs
> expression: formatted
12c12
< chainsight_common!(3600);
---
> chainsight_common!(60u32);
80c80
< ic_solidity_bindgen::contract_abi!("./__interfaces/ERC20.json");
---
> ic_solidity_bindgen::contract_abi!("examples/minimum_indexers/src/snapshot_indexer_evm/abi/ERC20.json");
87c87
< add_snapshot(datum.clone());
---
> let _ = add_snapshot(datum.clone());
```