### PR TITLE
Topic/use stable memory instead of heap - snapshot_indexer,relayer,algorithm_lens

### DIFF
--- a/chainsight-cdk-macros/src/canisters/algorithm_lens.rs
+++ b/chainsight-cdk-macros/src/canisters/algorithm_lens.rs
@@ -55,7 +55,7 @@ fn algorithm_lens_canister(config: AlgorithmLensConfig) -> proc_macro2::TokenStr
         use ic_stable_structures::writer::Writer;
         use ic_web3_rs::futures::{future::BoxFuture, FutureExt};
         chainsight_common!();
-        init_in!();
+        init_in!(1);
         prepare_stable_structure!();
         use #canister_name_ident::*;
         #lens_method_quote

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_evm.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_evm.rs
@@ -35,26 +35,26 @@ fn common_code(config: &CommonConfig) -> proc_macro2::TokenStream {
     quote! {
         use std::str::FromStr;
         use candid::{Decode, Encode};
-        use chainsight_cdk_macros::{init_in, manage_single_state, setup_func, prepare_stable_structure, stable_memory_for_vec, StableMemoryStorable, timer_task_func, define_transform_for_web3, define_web3_ctx, chainsight_common, did_export, CborSerde, snapshot_indexer_web3_source};
+        use chainsight_cdk_macros::{init_in, manage_single_state, setup_func, prepare_stable_structure, stable_memory_for_scalar, stable_memory_for_vec, StableMemoryStorable, timer_task_func, define_transform_for_web3, define_web3_ctx, chainsight_common, did_export, CborSerde, snapshot_indexer_web3_source};
         use ic_stable_structures::writer::Writer;
         use ic_web3_rs::types::Address;
 
         did_export!(#canister_name); // NOTE: need to be declared before query, update
 
-        init_in!();
+        init_in!(2);
         chainsight_common!();
 
-        define_web3_ctx!();
+        define_web3_ctx!(3);
         define_transform_for_web3!();
-        manage_single_state!("target_addr", String, false);
+        stable_memory_for_scalar!("target_addr", String, 4, false);
         setup_func!({
             target_addr: String,
             web3_ctx_param: chainsight_cdk::web3::Web3CtxParam
-        });
+        }, 5);
 
         prepare_stable_structure!();
         stable_memory_for_vec!("snapshot", Snapshot, 1, true);
-        timer_task_func!("set_task", "index");
+        timer_task_func!("set_task", "index", 6);
     }
 }
 

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_evm.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_evm.rs
@@ -212,7 +212,7 @@ fn custom_code(config: SnapshotIndexerEVMConfig) -> proc_macro2::TokenStream {
                 value: #response_values,
                 timestamp: current_ts_sec,
             };
-            let _ = add_snapshot(datum.clone());
+            add_snapshot(datum.clone());
 
             ic_cdk::println!("timestamp={}, value={:?}", datum.timestamp, datum.value);
         }

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_https.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_https.rs
@@ -156,7 +156,7 @@ fn custom_code(config: SnapshotIndexerHTTPSConfig) -> proc_macro2::TokenStream {
                 value: res,
                 timestamp: ic_cdk::api::time() / 1000000,
             };
-            let _ = add_snapshot(snapshot.clone());
+            add_snapshot(snapshot.clone());
 
             ic_cdk::println!("timestamp={}, value={:?}", snapshot.timestamp, snapshot.value);
         }

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_https.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_https.rs
@@ -104,7 +104,7 @@ fn custom_code(config: SnapshotIndexerHTTPSConfig) -> proc_macro2::TokenStream {
 
     quote! {
         did_export!(#id); // NOTE: need to be declared before query, update
-        init_in!();
+        init_in!(2);
         chainsight_common!();
         snapshot_indexer_https_source!();
 
@@ -116,7 +116,7 @@ fn custom_code(config: SnapshotIndexerHTTPSConfig) -> proc_macro2::TokenStream {
         }
         prepare_stable_structure!();
         stable_memory_for_vec!("snapshot", Snapshot, 1, true);
-        timer_task_func!("set_task", "index");
+        timer_task_func!("set_task", "index", 3);
 
         const URL : &str = #url;
         fn get_attrs() -> HttpsSnapshotIndexerSourceAttrs {

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_icp.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_icp.rs
@@ -213,7 +213,7 @@ fn custom_code(config: SnapshotIndexerICPConfig) -> proc_macro2::TokenStream {
                 value: value.clone(),
                 timestamp: current_ts_sec,
             };
-            let _ = add_snapshot(datum.clone());
+            add_snapshot(datum.clone());
 
             ic_cdk::println!("timestamp={}, value={:?}", datum.timestamp, datum.value);
         }

--- a/chainsight-cdk-macros/src/canisters/snapshot_indexer_icp.rs
+++ b/chainsight-cdk-macros/src/canisters/snapshot_indexer_icp.rs
@@ -37,7 +37,7 @@ fn common_code(config: &CommonConfig, with_lens: bool) -> proc_macro2::TokenStre
 
     quote! {
         use candid::{Decode, Encode};
-        use chainsight_cdk_macros::{init_in,manage_single_state, setup_func, prepare_stable_structure, stable_memory_for_vec, StableMemoryStorable, timer_task_func, chainsight_common, did_export, CborSerde, snapshot_indexer_icp_source};
+        use chainsight_cdk_macros::{init_in, manage_single_state, setup_func, prepare_stable_structure, stable_memory_for_scalar, stable_memory_for_vec, StableMemoryStorable, timer_task_func, chainsight_common, did_export, CborSerde, snapshot_indexer_icp_source};
         use chainsight_cdk::rpc::{CallProvider, Caller, Message};
         use ic_stable_structures::writer::Writer;
 
@@ -45,10 +45,10 @@ fn common_code(config: &CommonConfig, with_lens: bool) -> proc_macro2::TokenStre
 
         did_export!(#id); // NOTE: need to be declared before query, update
 
-        init_in!();
+        init_in!(2);
         chainsight_common!();
 
-        manage_single_state!("target_canister", String, false);
+        stable_memory_for_scalar!("target_canister", String, 3, false);
         setup_func!({
             target_canister: String,
             #lens_targets_quote
@@ -56,7 +56,7 @@ fn common_code(config: &CommonConfig, with_lens: bool) -> proc_macro2::TokenStre
 
         prepare_stable_structure!();
         stable_memory_for_vec!("snapshot", Snapshot, 1, true);
-        timer_task_func!("set_task", "index");
+        timer_task_func!("set_task", "index", 4);
     }
 }
 
@@ -119,7 +119,7 @@ fn custom_code(config: SnapshotIndexerICPConfig) -> proc_macro2::TokenStream {
         };
         (
             quote! {
-                manage_single_state!("lens_targets", Vec<String>, false);
+                manage_single_state!("lens_targets", Vec<String>, false); // todo: should use stable memory, but `Storable` isn't implemented for `Vec<String>`
                 #call_args_ident
             },
             quote! { snapshot_indexer_icp_source!(#method_ident, "get_lens_targets"); },

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__algorithm_lens__test__snapshot__algorithm_lens.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__algorithm_lens__test__snapshot__algorithm_lens.snap
@@ -11,7 +11,7 @@ use chainsight_cdk_macros::{
 use ic_stable_structures::writer::Writer;
 use ic_web3_rs::futures::{future::BoxFuture, FutureExt};
 chainsight_common!();
-init_in!();
+init_in!(1);
 prepare_stable_structure!();
 use app::*;
 lens_method!(10usize);

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__algorithm_lens__test__snapshot__algorithm_lens_with_args.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__algorithm_lens__test__snapshot__algorithm_lens_with_args.snap
@@ -11,7 +11,7 @@ use chainsight_cdk_macros::{
 use ic_stable_structures::writer::Writer;
 use ic_web3_rs::futures::{future::BoxFuture, FutureExt};
 chainsight_common!();
-init_in!();
+init_in!(1);
 prepare_stable_structure!();
 use app::*;
 lens_method!(10usize, CalculateArgs);

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__relayer__test__snapshot__relayer.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__relayer__test__snapshot__relayer.snap
@@ -9,7 +9,7 @@ use chainsight_cdk::web3::Encoder;
 use chainsight_cdk_macros::{
     chainsight_common, define_get_ethereum_address, define_transform_for_web3, define_web3_ctx,
     did_export, init_in, manage_single_state, prepare_stable_structure, relayer_source, setup_func,
-    timer_task_func, CborSerde, StableMemoryStorable,
+    stable_memory_for_scalar, timer_task_func, CborSerde, StableMemoryStorable,
 };
 use ic_cdk::api::call::result;
 use ic_stable_structures::writer::Writer;
@@ -17,15 +17,15 @@ use ic_web3_rs::types::{Address, U256};
 use std::str::FromStr;
 did_export!("relayer");
 chainsight_common!();
-define_web3_ctx!();
+define_web3_ctx!(2);
 define_transform_for_web3!();
-manage_single_state!("target_addr", String, false);
+stable_memory_for_scalar!("target_addr", String, 3, false);
 define_get_ethereum_address!();
-manage_single_state!("target_canister", String, false);
+stable_memory_for_scalar!("target_canister", String, 4, false);
 prepare_stable_structure!();
-timer_task_func!("set_task", "index");
-init_in!();
-setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam , target_canister : String , });
+timer_task_func!("set_task", "index", 6);
+init_in!(1);
+setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam , target_canister : String , } , 5);
 ic_solidity_bindgen::contract_abi!("__interfaces/Uint256Oracle.json");
 use relayer::{filter, CallCanisterResponse};
 type CallCanisterArgs = relayer::CallCanisterArgs;

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__relayer__test__snapshot__relayer__with_converted_val_from_extracted.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__relayer__test__snapshot__relayer__with_converted_val_from_extracted.snap
@@ -9,7 +9,7 @@ use chainsight_cdk::web3::Encoder;
 use chainsight_cdk_macros::{
     chainsight_common, define_get_ethereum_address, define_transform_for_web3, define_web3_ctx,
     did_export, init_in, manage_single_state, prepare_stable_structure, relayer_source, setup_func,
-    timer_task_func, CborSerde, StableMemoryStorable,
+    stable_memory_for_scalar, timer_task_func, CborSerde, StableMemoryStorable,
 };
 use ic_cdk::api::call::result;
 use ic_stable_structures::writer::Writer;
@@ -17,15 +17,15 @@ use ic_web3_rs::types::{Address, U256};
 use std::str::FromStr;
 did_export!("relayer");
 chainsight_common!();
-define_web3_ctx!();
+define_web3_ctx!(2);
 define_transform_for_web3!();
-manage_single_state!("target_addr", String, false);
+stable_memory_for_scalar!("target_addr", String, 3, false);
 define_get_ethereum_address!();
-manage_single_state!("target_canister", String, false);
+stable_memory_for_scalar!("target_canister", String, 4, false);
 prepare_stable_structure!();
-timer_task_func!("set_task", "index");
-init_in!();
-setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam , target_canister : String , });
+timer_task_func!("set_task", "index", 6);
+init_in!(1);
+setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam , target_canister : String , } , 5);
 ic_solidity_bindgen::contract_abi!("__interfaces/Uint256Oracle.json");
 use relayer::{filter, CallCanisterResponse};
 type CallCanisterArgs = relayer::CallCanisterArgs;

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__relayer__test__snapshot__relayer__with_extracted_val_from_response.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__relayer__test__snapshot__relayer__with_extracted_val_from_response.snap
@@ -9,7 +9,7 @@ use chainsight_cdk::web3::Encoder;
 use chainsight_cdk_macros::{
     chainsight_common, define_get_ethereum_address, define_transform_for_web3, define_web3_ctx,
     did_export, init_in, manage_single_state, prepare_stable_structure, relayer_source, setup_func,
-    timer_task_func, CborSerde, StableMemoryStorable,
+    stable_memory_for_scalar, timer_task_func, CborSerde, StableMemoryStorable,
 };
 use ic_cdk::api::call::result;
 use ic_stable_structures::writer::Writer;
@@ -17,15 +17,15 @@ use ic_web3_rs::types::{Address, U256};
 use std::str::FromStr;
 did_export!("relayer");
 chainsight_common!();
-define_web3_ctx!();
+define_web3_ctx!(2);
 define_transform_for_web3!();
-manage_single_state!("target_addr", String, false);
+stable_memory_for_scalar!("target_addr", String, 3, false);
 define_get_ethereum_address!();
-manage_single_state!("target_canister", String, false);
+stable_memory_for_scalar!("target_canister", String, 4, false);
 prepare_stable_structure!();
-timer_task_func!("set_task", "index");
-init_in!();
-setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam , target_canister : String , });
+timer_task_func!("set_task", "index", 6);
+init_in!(1);
+setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam , target_canister : String , } , 5);
 ic_solidity_bindgen::contract_abi!("__interfaces/Uint256Oracle.json");
 use relayer::{filter, CallCanisterResponse};
 type CallCanisterArgs = relayer::CallCanisterArgs;

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__relayer__test__snapshot__relayer__with_lens.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__relayer__test__snapshot__relayer__with_lens.snap
@@ -9,7 +9,7 @@ use chainsight_cdk::web3::Encoder;
 use chainsight_cdk_macros::{
     chainsight_common, define_get_ethereum_address, define_transform_for_web3, define_web3_ctx,
     did_export, init_in, manage_single_state, prepare_stable_structure, relayer_source, setup_func,
-    timer_task_func, CborSerde, StableMemoryStorable,
+    stable_memory_for_scalar, timer_task_func, CborSerde, StableMemoryStorable,
 };
 use ic_cdk::api::call::result;
 use ic_stable_structures::writer::Writer;
@@ -17,15 +17,15 @@ use ic_web3_rs::types::{Address, U256};
 use std::str::FromStr;
 did_export!("relayer");
 chainsight_common!();
-define_web3_ctx!();
+define_web3_ctx!(2);
 define_transform_for_web3!();
-manage_single_state!("target_addr", String, false);
+stable_memory_for_scalar!("target_addr", String, 3, false);
 define_get_ethereum_address!();
-manage_single_state!("target_canister", String, false);
+stable_memory_for_scalar!("target_canister", String, 4, false);
 prepare_stable_structure!();
-timer_task_func!("set_task", "index");
-init_in!();
-setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam , target_canister : String , lens_targets : Vec < String > });
+timer_task_func!("set_task", "index", 6);
+init_in!(1);
+setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam , target_canister : String , lens_targets : Vec < String > } , 5);
 ic_solidity_bindgen::contract_abi!("__interfaces/Uint256Oracle.json");
 use relayer::{filter, CallCanisterResponse};
 manage_single_state!("lens_targets", Vec<String>, false);

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__relayer__test__snapshot__relayer__with_lens_with_args.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__relayer__test__snapshot__relayer__with_lens_with_args.snap
@@ -9,7 +9,7 @@ use chainsight_cdk::web3::Encoder;
 use chainsight_cdk_macros::{
     chainsight_common, define_get_ethereum_address, define_transform_for_web3, define_web3_ctx,
     did_export, init_in, manage_single_state, prepare_stable_structure, relayer_source, setup_func,
-    timer_task_func, CborSerde, StableMemoryStorable,
+    stable_memory_for_scalar, timer_task_func, CborSerde, StableMemoryStorable,
 };
 use ic_cdk::api::call::result;
 use ic_stable_structures::writer::Writer;
@@ -17,15 +17,15 @@ use ic_web3_rs::types::{Address, U256};
 use std::str::FromStr;
 did_export!("relayer");
 chainsight_common!();
-define_web3_ctx!();
+define_web3_ctx!(2);
 define_transform_for_web3!();
-manage_single_state!("target_addr", String, false);
+stable_memory_for_scalar!("target_addr", String, 3, false);
 define_get_ethereum_address!();
-manage_single_state!("target_canister", String, false);
+stable_memory_for_scalar!("target_canister", String, 4, false);
 prepare_stable_structure!();
-timer_task_func!("set_task", "index");
-init_in!();
-setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam , target_canister : String , lens_targets : Vec < String > });
+timer_task_func!("set_task", "index", 6);
+init_in!(1);
+setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam , target_canister : String , lens_targets : Vec < String > } , 5);
 ic_solidity_bindgen::contract_abi!("__interfaces/Uint256Oracle.json");
 use relayer::{filter, CallCanisterResponse};
 manage_single_state!("lens_targets", Vec<String>, false);

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__relayer__test__snapshot__relayer__with_scaled_val_from_extracted.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__relayer__test__snapshot__relayer__with_scaled_val_from_extracted.snap
@@ -9,7 +9,7 @@ use chainsight_cdk::web3::Encoder;
 use chainsight_cdk_macros::{
     chainsight_common, define_get_ethereum_address, define_transform_for_web3, define_web3_ctx,
     did_export, init_in, manage_single_state, prepare_stable_structure, relayer_source, setup_func,
-    timer_task_func, CborSerde, StableMemoryStorable,
+    stable_memory_for_scalar, timer_task_func, CborSerde, StableMemoryStorable,
 };
 use ic_cdk::api::call::result;
 use ic_stable_structures::writer::Writer;
@@ -17,15 +17,15 @@ use ic_web3_rs::types::{Address, U256};
 use std::str::FromStr;
 did_export!("relayer");
 chainsight_common!();
-define_web3_ctx!();
+define_web3_ctx!(2);
 define_transform_for_web3!();
-manage_single_state!("target_addr", String, false);
+stable_memory_for_scalar!("target_addr", String, 3, false);
 define_get_ethereum_address!();
-manage_single_state!("target_canister", String, false);
+stable_memory_for_scalar!("target_canister", String, 4, false);
 prepare_stable_structure!();
-timer_task_func!("set_task", "index");
-init_in!();
-setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam , target_canister : String , });
+timer_task_func!("set_task", "index", 6);
+init_in!(1);
+setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam , target_canister : String , } , 5);
 ic_solidity_bindgen::contract_abi!("__interfaces/Uint256Oracle.json");
 use relayer::{filter, CallCanisterResponse};
 type CallCanisterArgs = relayer::CallCanisterArgs;

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_evm__test__snapshot__snapshot_indexer_evm.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_evm__test__snapshot__snapshot_indexer_evm.snap
@@ -6,21 +6,22 @@ use candid::{Decode, Encode};
 use chainsight_cdk_macros::{
     chainsight_common, define_transform_for_web3, define_web3_ctx, did_export, init_in,
     manage_single_state, prepare_stable_structure, setup_func, snapshot_indexer_web3_source,
-    stable_memory_for_vec, timer_task_func, CborSerde, StableMemoryStorable,
+    stable_memory_for_scalar, stable_memory_for_vec, timer_task_func, CborSerde,
+    StableMemoryStorable,
 };
 use ic_stable_structures::writer::Writer;
 use ic_web3_rs::types::Address;
 use std::str::FromStr;
 did_export!("sample_snapshot_indexer_evm");
-init_in!();
+init_in!(2);
 chainsight_common!();
-define_web3_ctx!();
+define_web3_ctx!(3);
 define_transform_for_web3!();
-manage_single_state!("target_addr", String, false);
-setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam });
+stable_memory_for_scalar!("target_addr", String, 4, false);
+setup_func ! ({ target_addr : String , web3_ctx_param : chainsight_cdk :: web3 :: Web3CtxParam } , 5);
 prepare_stable_structure!();
 stable_memory_for_vec!("snapshot", Snapshot, 1, true);
-timer_task_func!("set_task", "index");
+timer_task_func!("set_task", "index", 6);
 #[derive(
     Debug,
     Clone,
@@ -114,7 +115,7 @@ async fn index() {
         value: res.to_string(),
         timestamp: current_ts_sec,
     };
-    let _ = add_snapshot(datum.clone());
+    add_snapshot(datum.clone());
     ic_cdk::println!("timestamp={}, value={:?}", datum.timestamp, datum.value);
 }
 #[derive(

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_https__test__snapshot__snapshot_indexer_https.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_https__test__snapshot__snapshot_indexer_https.snap
@@ -14,7 +14,7 @@ use ic_stable_structures::writer::Writer;
 use sample_snapshot_indexer_https::*;
 use std::collections::HashMap;
 did_export!("sample_snapshot_indexer_https");
-init_in!();
+init_in!(2);
 chainsight_common!();
 snapshot_indexer_https_source!();
 #[derive(
@@ -32,7 +32,7 @@ pub struct Snapshot {
 }
 prepare_stable_structure!();
 stable_memory_for_vec!("snapshot", Snapshot, 1, true);
-timer_task_func!("set_task", "index");
+timer_task_func!("set_task", "index", 3);
 const URL: &str = "https://api.coingecko.com/api/v3/simple/price";
 fn get_attrs() -> HttpsSnapshotIndexerSourceAttrs {
     HttpsSnapshotIndexerSourceAttrs {
@@ -75,7 +75,7 @@ async fn index() {
         value: res,
         timestamp: ic_cdk::api::time() / 1000000,
     };
-    let _ = add_snapshot(snapshot.clone());
+    add_snapshot(snapshot.clone());
     ic_cdk::println!(
         "timestamp={}, value={:?}",
         snapshot.timestamp,

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_https__test__snapshot__snapshot_indexer_https__custom_query.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_https__test__snapshot__snapshot_indexer_https__custom_query.snap
@@ -14,7 +14,7 @@ use ic_stable_structures::writer::Writer;
 use sample_snapshot_indexer_https::*;
 use std::collections::HashMap;
 did_export!("sample_snapshot_indexer_https");
-init_in!();
+init_in!(2);
 chainsight_common!();
 snapshot_indexer_https_source!();
 #[derive(
@@ -32,7 +32,7 @@ pub struct Snapshot {
 }
 prepare_stable_structure!();
 stable_memory_for_vec!("snapshot", Snapshot, 1, true);
-timer_task_func!("set_task", "index");
+timer_task_func!("set_task", "index", 3);
 const URL: &str = "https://api.coingecko.com/api/v3/simple/price";
 fn get_attrs() -> HttpsSnapshotIndexerSourceAttrs {
     HttpsSnapshotIndexerSourceAttrs {
@@ -73,7 +73,7 @@ async fn index() {
         value: res,
         timestamp: ic_cdk::api::time() / 1000000,
     };
-    let _ = add_snapshot(snapshot.clone());
+    add_snapshot(snapshot.clone());
     ic_cdk::println!(
         "timestamp={}, value={:?}",
         snapshot.timestamp,

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp.snap
@@ -6,19 +6,19 @@ use candid::{Decode, Encode};
 use chainsight_cdk::rpc::{CallProvider, Caller, Message};
 use chainsight_cdk_macros::{
     chainsight_common, did_export, init_in, manage_single_state, prepare_stable_structure,
-    setup_func, snapshot_indexer_icp_source, stable_memory_for_vec, timer_task_func, CborSerde,
-    StableMemoryStorable,
+    setup_func, snapshot_indexer_icp_source, stable_memory_for_scalar, stable_memory_for_vec,
+    timer_task_func, CborSerde, StableMemoryStorable,
 };
 use ic_stable_structures::writer::Writer;
 mod types;
 did_export!("sample_snapshot_indexer_icp");
-init_in!();
+init_in!(2);
 chainsight_common!();
-manage_single_state!("target_canister", String, false);
+stable_memory_for_scalar!("target_canister", String, 3, false);
 setup_func ! ({ target_canister : String , });
 prepare_stable_structure!();
 stable_memory_for_vec!("snapshot", Snapshot, 1, true);
-timer_task_func!("set_task", "index");
+timer_task_func!("set_task", "index", 4);
 #[derive(
     Clone,
     Debug,
@@ -128,7 +128,7 @@ async fn index() {
         value: value.clone(),
         timestamp: current_ts_sec,
     };
-    let _ = add_snapshot(datum.clone());
+    add_snapshot(datum.clone());
     ic_cdk::println!("timestamp={}, value={:?}", datum.timestamp, datum.value);
 }
 #[derive(

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp__target_is_not_component.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp__target_is_not_component.snap
@@ -6,19 +6,19 @@ use candid::{Decode, Encode};
 use chainsight_cdk::rpc::{CallProvider, Caller, Message};
 use chainsight_cdk_macros::{
     chainsight_common, did_export, init_in, manage_single_state, prepare_stable_structure,
-    setup_func, snapshot_indexer_icp_source, stable_memory_for_vec, timer_task_func, CborSerde,
-    StableMemoryStorable,
+    setup_func, snapshot_indexer_icp_source, stable_memory_for_scalar, stable_memory_for_vec,
+    timer_task_func, CborSerde, StableMemoryStorable,
 };
 use ic_stable_structures::writer::Writer;
 mod types;
 did_export!("sample_snapshot_indexer_icp");
-init_in!();
+init_in!(2);
 chainsight_common!();
-manage_single_state!("target_canister", String, false);
+stable_memory_for_scalar!("target_canister", String, 3, false);
 setup_func ! ({ target_canister : String , });
 prepare_stable_structure!();
 stable_memory_for_vec!("snapshot", Snapshot, 1, true);
-timer_task_func!("set_task", "index");
+timer_task_func!("set_task", "index", 4);
 #[derive(
     Clone,
     Debug,
@@ -120,7 +120,7 @@ async fn index() {
         value: value.clone(),
         timestamp: current_ts_sec,
     };
-    let _ = add_snapshot(datum.clone());
+    add_snapshot(datum.clone());
     ic_cdk::println!("timestamp={}, value={:?}", datum.timestamp, datum.value);
 }
 #[derive(

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp__with_lens.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp__with_lens.snap
@@ -6,19 +6,19 @@ use candid::{Decode, Encode};
 use chainsight_cdk::rpc::{CallProvider, Caller, Message};
 use chainsight_cdk_macros::{
     chainsight_common, did_export, init_in, manage_single_state, prepare_stable_structure,
-    setup_func, snapshot_indexer_icp_source, stable_memory_for_vec, timer_task_func, CborSerde,
-    StableMemoryStorable,
+    setup_func, snapshot_indexer_icp_source, stable_memory_for_scalar, stable_memory_for_vec,
+    timer_task_func, CborSerde, StableMemoryStorable,
 };
 use ic_stable_structures::writer::Writer;
 mod types;
 did_export!("sample_snapshot_indexer_icp");
-init_in!();
+init_in!(2);
 chainsight_common!();
-manage_single_state!("target_canister", String, false);
+stable_memory_for_scalar!("target_canister", String, 3, false);
 setup_func ! ({ target_canister : String , lens_targets : Vec < String > });
 prepare_stable_structure!();
 stable_memory_for_vec!("snapshot", Snapshot, 1, true);
-timer_task_func!("set_task", "index");
+timer_task_func!("set_task", "index", 4);
 #[derive(
     Clone,
     Debug,
@@ -129,7 +129,7 @@ async fn index() {
         value: value.clone(),
         timestamp: current_ts_sec,
     };
-    let _ = add_snapshot(datum.clone());
+    add_snapshot(datum.clone());
     ic_cdk::println!("timestamp={}, value={:?}", datum.timestamp, datum.value);
 }
 #[derive(

--- a/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp__with_lens_with_args.snap
+++ b/chainsight-cdk-macros/src/canisters/snapshots/chainsight_cdk_macros__canisters__snapshot_indexer_icp__test__snapshot__snapshot_indexer_icp__with_lens_with_args.snap
@@ -6,19 +6,19 @@ use candid::{Decode, Encode};
 use chainsight_cdk::rpc::{CallProvider, Caller, Message};
 use chainsight_cdk_macros::{
     chainsight_common, did_export, init_in, manage_single_state, prepare_stable_structure,
-    setup_func, snapshot_indexer_icp_source, stable_memory_for_vec, timer_task_func, CborSerde,
-    StableMemoryStorable,
+    setup_func, snapshot_indexer_icp_source, stable_memory_for_scalar, stable_memory_for_vec,
+    timer_task_func, CborSerde, StableMemoryStorable,
 };
 use ic_stable_structures::writer::Writer;
 mod types;
 did_export!("sample_snapshot_indexer_icp");
-init_in!();
+init_in!(2);
 chainsight_common!();
-manage_single_state!("target_canister", String, false);
+stable_memory_for_scalar!("target_canister", String, 3, false);
 setup_func ! ({ target_canister : String , lens_targets : Vec < String > });
 prepare_stable_structure!();
 stable_memory_for_vec!("snapshot", Snapshot, 1, true);
-timer_task_func!("set_task", "index");
+timer_task_func!("set_task", "index", 4);
 #[derive(
     Clone,
     Debug,
@@ -130,7 +130,7 @@ async fn index() {
         value: value.clone(),
         timestamp: current_ts_sec,
     };
-    let _ = add_snapshot(datum.clone());
+    add_snapshot(datum.clone());
     ic_cdk::println!("timestamp={}, value={:?}", datum.timestamp, datum.value);
 }
 #[derive(

--- a/chainsight-cdk-macros/src/functions.rs
+++ b/chainsight-cdk-macros/src/functions.rs
@@ -145,7 +145,7 @@ fn setup_func_internal(input: SetupArgs) -> proc_macro2::TokenStream {
     // If stable_memory_id is specified, use Stable Memory, otherwise use Heap Memory
     let storage_quote = if let Some(memory_id) = stable_memory_id {
         quote! {
-            stable_memory_for_scalar!("setup_flag", StorableBool, #memory_id, false);
+            stable_memory_for_scalar!("setup_flag", chainsight_cdk::storage::StorableBool, #memory_id, false);
         }
     } else {
         quote! {

--- a/chainsight-cdk-macros/src/snapshots/chainsight_cdk_macros__functions__test__snapshot__setup_func_with_stable_memory.snap
+++ b/chainsight-cdk-macros/src/snapshots/chainsight_cdk_macros__functions__test__snapshot__setup_func_with_stable_memory.snap
@@ -2,7 +2,12 @@
 source: chainsight-cdk-macros/src/functions.rs
 expression: formatted
 ---
-stable_memory_for_scalar!("setup_flag", StorableBool, 0, false);
+stable_memory_for_scalar!(
+    "setup_flag",
+    chainsight_cdk::storage::StorableBool,
+    0,
+    false
+);
 #[ic_cdk::update]
 #[candid::candid_method(update)]
 fn setup(

--- a/chainsight-cdk-macros/src/snapshots/chainsight_cdk_macros__storages__test__snapshot__stable_memory_for_scalar.snap
+++ b/chainsight-cdk-macros/src/snapshots/chainsight_cdk_macros__storages__test__snapshot__stable_memory_for_scalar.snap
@@ -8,7 +8,10 @@ thread_local! { static TIMESTAMP : std :: cell :: RefCell < ic_stable_structures
 pub fn get_timestamp() -> u64 {
     TIMESTAMP.with(|cell| cell.borrow().get().clone())
 }
-pub fn set_timestamp(value: u64) -> Result<(), String> {
+pub fn set_timestamp(value: u64) {
+    set_timestamp_internal(value).unwrap()
+}
+pub fn set_timestamp_internal(value: u64) -> Result<(), String> {
     let res = TIMESTAMP.with(|cell| cell.borrow_mut().set(value));
     res.map(|_| ()).map_err(|e| format!("{:?}", e))
 }

--- a/chainsight-cdk-macros/src/snapshots/chainsight_cdk_macros__storages__test__snapshot__stable_memory_for_vec.snap
+++ b/chainsight-cdk-macros/src/snapshots/chainsight_cdk_macros__storages__test__snapshot__stable_memory_for_vec.snap
@@ -100,7 +100,10 @@ async fn proxy_get_timestamp(input: std::vec::Vec<u8>) -> std::vec::Vec<u8> {
         .reply(input)
         .await
 }
-pub fn add_timestamp(value: u64) -> Result<(), String> {
+pub fn add_timestamp(value: u64) {
+    add_timestamp_internal(value).unwrap()
+}
+pub fn add_timestamp_internal(value: u64) -> Result<(), String> {
     let res = TIMESTAMPS.with(|vec| vec.borrow_mut().push(&value));
     res.map_err(|e| format!("{:?}", e))
 }

--- a/chainsight-cdk-macros/tests/function_init_in_env_with_stable_memory.rs
+++ b/chainsight-cdk-macros/tests/function_init_in_env_with_stable_memory.rs
@@ -20,7 +20,7 @@ mod test_init_in_env_with_stable_memory {
             proxy: candid::Principal::anonymous().to_text(),
             env: chainsight_cdk::core::Env::Production,
         };
-        assert!(set_initializing_state(updated.clone()).is_ok());
+        assert!(set_initializing_state_internal(updated.clone()).is_ok());
 
         assert_eq!(get_initializing_state(), updated);
         assert_eq!(

--- a/chainsight-cdk-macros/tests/function_setup_with_stable_memory.rs
+++ b/chainsight-cdk-macros/tests/function_setup_with_stable_memory.rs
@@ -1,6 +1,5 @@
 #[allow(unused_must_use)]
 mod function_setup_with_stable_memory {
-    use chainsight_cdk::storage::StorableBool;
     use chainsight_cdk_macros::{
         manage_single_state, prepare_stable_structure, setup_func, stable_memory_for_scalar,
     };

--- a/chainsight-cdk-macros/tests/web3_define_web3_ctx_with_stable_memory.rs
+++ b/chainsight-cdk-macros/tests/web3_define_web3_ctx_with_stable_memory.rs
@@ -21,7 +21,7 @@ mod test_define_web3_ctx_with_stable_memory {
             chain_id: 1,
             env: chainsight_cdk::core::Env::Production,
         };
-        assert!(set_web3_ctx_param(ctx_param.clone()).is_ok());
+        assert!(set_web3_ctx_param_internal(ctx_param.clone()).is_ok());
         assert_eq!(get_web3_ctx_param(), ctx_param);
 
         let ctx = web3_ctx().unwrap();


### PR DESCRIPTION
note
- except algorithm_indxer,event_indexer
- except lens_target (because vec<string> is not storable by default)