### PR TITLE
fix: web3 module - last_indexed in .index

### DIFF
--- a/chainsight-cdk/src/web3/web3.rs
+++ b/chainsight-cdk/src/web3/web3.rs
@@ -131,7 +131,7 @@ where
     E: Event<EventLog> + Persist,
 {
     async fn index(&self, cfg: IndexingConfig) -> Result<(), Error> {
-        let last_indexed = self.get_last_indexed()?;
+        let last_indexed = self.get_last_indexed().unwrap_or(0);
         let chunk_size = cfg.chunk_size.unwrap_or(500);
         let from = cfg.start_from.max(last_indexed + 1);
         let to = from + chunk_size;


### PR DESCRIPTION
ref: previous implement
https://github.com/horizonx-tech/chainsight-sdk/pull/126/commits/9ab85daa984a4dba85770ad12776e346c10a73c0#diff-46dd55d5ecd4993392dfe30a8637869a521ed466821050cc610d6e9e2f3143f5